### PR TITLE
Regenerate gl bindings using latest glow, add go generate directives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The `procaddr` package contains platform-specific functions for [loading OpenGL 
 Generating
 ----------
 
-These gl bindings are generated using `glow` generator.
+These gl bindings are generated using `glow` generator. Only developers of this repository need to do this step.
+
+It is required to have glow source in the same Go workspace (since relative paths are used) and the glow generator installed, doable with `go get -u github.com/go-gl/glow`.
 
 ```bash
 go generate -tags=gen github.com/go-gl/gl

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Examples
 
 Examples illustrating how to use the bindings are available in the [examples](https://github.com/go-gl/examples) repo. There are examples for [OpenGL 4.1 core](https://github.com/go-gl/examples/blob/master/glfw31-gl41core-cube) and [OpenGL 2.1](https://github.com/go-gl/examples/tree/master/glfw31-gl21-cube).
 
+Function Loading
+----------------
+
+The `procaddr` package contains platform-specific functions for [loading OpenGL functions](https://www.opengl.org/wiki/Load_OpenGL_Functions). Calling `gl.Init()` uses the `auto` subpackage to automatically select an appropriate implementation based on the build environment. If you want to select a specific implementation you can use the `noauto` build tag and the `gl.InitWithProcAddrFunc` initialization function.
+
 More
 ----
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Function Loading
 
 The `procaddr` package contains platform-specific functions for [loading OpenGL functions](https://www.opengl.org/wiki/Load_OpenGL_Functions). Calling `gl.Init()` uses the `auto` subpackage to automatically select an appropriate implementation based on the build environment. If you want to select a specific implementation you can use the `noauto` build tag and the `gl.InitWithProcAddrFunc` initialization function.
 
-More
-----
+Generating
+----------
+
+These gl bindings are generated using `glow` generator.
+
+```bash
+go generate -tags=gen github.com/go-gl/gl
+```
 
 More information about these bindings can be found in the [Glow repository](https://github.com/go-gl/glow).

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The `procaddr` package contains platform-specific functions for [loading OpenGL 
 Generating
 ----------
 
-These gl bindings are generated using `glow` generator. Only developers of this repository need to do this step.
+These gl bindings are generated using the [Glow](https://github.com/go-gl/glow) generator. Only developers of this repository need to do this step.
 
-It is required to have glow source in the same Go workspace (since relative paths are used) and the glow generator installed, doable with `go get -u github.com/go-gl/glow`.
+It is required to have `glow` source in the same Go workspace (since relative paths are used) and the `glow` binary should be in your `$PATH`. Doable with `go get -u github.com/go-gl/glow` if your `$GOPATH/bin` is in your `$PATH`.
 
 ```bash
 go generate -tags=gen github.com/go-gl/gl

--- a/all-core/gl/conversions.go
+++ b/all-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,18 @@
+// +build gen
+
+//go:generate glow generate -out=./v2.1/gl/ -api=gl -version=2.1 -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./all-core/gl/ -api=gl -version=all -profile=core -lenientInit -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v3.2-core/gl/ -api=gl -version=3.2 -profile=core -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v3.3-core/gl/ -api=gl -version=3.3 -profile=core -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.1-core/gl/ -api=gl -version=4.1 -profile=core -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.4-core/gl/ -api=gl -version=4.4 -profile=core -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.5-core/gl/ -api=gl -version=4.5 -profile=core -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v3.2-compatibility/gl/ -api=gl -version=3.2 -profile=compatibility -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v3.3-compatibility/gl/ -api=gl -version=3.3 -profile=compatibility -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.1-compatibility/gl/ -api=gl -version=4.1 -profile=compatibility -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.4-compatibility/gl/ -api=gl -version=4.4 -profile=compatibility -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+//go:generate glow generate -out=./v4.5-compatibility/gl/ -api=gl -version=4.5 -profile=compatibility -xml=../glow/xml/ -prefix=github.com/go-gl/gl
+
+// This is an empty pseudo-package with the sole purpose of containing go generate directives
+// that generate all gl binding packages inside this repository.
+package gl

--- a/v2.1/gl/conversions.go
+++ b/v2.1/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v3.2-compatibility/gl/conversions.go
+++ b/v3.2-compatibility/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v3.2-core/gl/conversions.go
+++ b/v3.2-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v3.3-compatibility/gl/conversions.go
+++ b/v3.3-compatibility/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v3.3-core/gl/conversions.go
+++ b/v3.3-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.1-compatibility/gl/conversions.go
+++ b/v4.1-compatibility/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.1-core/gl/conversions.go
+++ b/v4.1-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.4-compatibility/gl/conversions.go
+++ b/v4.4-compatibility/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.4-core/gl/conversions.go
+++ b/v4.4-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.5-compatibility/gl/conversions.go
+++ b/v4.5-compatibility/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}

--- a/v4.5-core/gl/conversions.go
+++ b/v4.5-core/gl/conversions.go
@@ -11,7 +11,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -32,8 +33,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}


### PR DESCRIPTION
Fixes #8.
Closes #2.

Can be merged as is, but the `go generate` functionality depends on go-gl/glow#56 being merged.