### PR TITLE
Add libgl1-mesa-dev requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Features:
 - Support for extensions (including debug callbacks).
 
 Requirements:
-- A cgo compiler (typically gcc)
+- A cgo compiler (typically gcc).
+- The `libgl1-mesa-dev` package.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features:
 
 Requirements:
 - A cgo compiler (typically gcc).
-- The `libgl1-mesa-dev` package.
+- On Ubuntu/Debian-based systems, the `libgl1-mesa-dev` package.
 
 Usage
 -----


### PR DESCRIPTION
Modified README to include the mesa requirement.

Closes #25.