### PR TITLE
all: Represent GLsync as uintptr, not unsafe.Pointer.

### DIFF
--- a/all-core/gl/package.go
+++ b/all-core/gl/package.go
@@ -7711,7 +7711,7 @@ func ClientActiveTexture(texture uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -7998,9 +7998,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -8108,7 +8108,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -8386,9 +8386,9 @@ func FeedbackBuffer(size int32, xtype uint32, buffer *float32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -8975,7 +8975,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexEnvfv(target uint32, pname uint32, params *float32) {
@@ -9369,7 +9369,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -11479,7 +11479,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WindowPos2d(x float64, y float64) {

--- a/v2.1/gl/package.go
+++ b/v2.1/gl/package.go
@@ -18437,7 +18437,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -19010,9 +19010,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -19198,7 +19198,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -19652,9 +19652,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -21002,7 +21002,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -21440,9 +21440,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -21715,7 +21715,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -26562,7 +26562,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v3.1/gles2/package.go
+++ b/v3.1/gles2/package.go
@@ -4634,11 +4634,11 @@ func ClearStencil(s int32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
-func ClientWaitSyncAPPLE(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSyncAPPLE(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSyncAPPLE(gpClientWaitSyncAPPLE, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -4834,10 +4834,10 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
-func DeleteSyncAPPLE(sync unsafe.Pointer) {
+func DeleteSyncAPPLE(sync uintptr) {
 	C.glowDeleteSyncAPPLE(gpDeleteSyncAPPLE, (C.GLsync)(sync))
 }
 
@@ -5049,13 +5049,13 @@ func ExtTexObjectStateOverrideiQCOM(target uint32, pname uint32, param int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
-func FenceSyncAPPLE(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSyncAPPLE(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSyncAPPLE(gpFenceSyncAPPLE, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -5510,10 +5510,10 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
-func GetSyncivAPPLE(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSyncivAPPLE(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSyncivAPPLE(gpGetSyncivAPPLE, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexLevelParameterfv(target uint32, level int32, pname uint32, params *float32) {
@@ -5709,11 +5709,11 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
-func IsSyncAPPLE(sync unsafe.Pointer) bool {
+func IsSyncAPPLE(sync uintptr) bool {
 	ret := C.glowIsSyncAPPLE(gpIsSyncAPPLE, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -6676,10 +6676,10 @@ func Viewport(x int32, y int32, width int32, height int32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
-func WaitSyncAPPLE(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSyncAPPLE(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSyncAPPLE(gpWaitSyncAPPLE, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v3.2-compatibility/gl/package.go
+++ b/v3.2-compatibility/gl/package.go
@@ -19375,7 +19375,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20021,9 +20021,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20209,7 +20209,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20685,9 +20685,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22113,7 +22113,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22616,9 +22616,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22895,7 +22895,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -27964,7 +27964,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v3.2-core/gl/package.go
+++ b/v3.2-core/gl/package.go
@@ -5408,7 +5408,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5579,9 +5579,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5684,7 +5684,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5889,9 +5889,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6398,7 +6398,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6708,7 +6708,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8100,7 +8100,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v3.3-compatibility/gl/package.go
+++ b/v3.3-compatibility/gl/package.go
@@ -19381,7 +19381,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20027,9 +20027,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20215,7 +20215,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20691,9 +20691,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22119,7 +22119,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22622,9 +22622,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22901,7 +22901,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -27975,7 +27975,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v3.3-core/gl/package.go
+++ b/v3.3-core/gl/package.go
@@ -5414,7 +5414,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5585,9 +5585,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5690,7 +5690,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5895,9 +5895,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6404,7 +6404,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6714,7 +6714,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8111,7 +8111,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v4.1-compatibility/gl/package.go
+++ b/v4.1-compatibility/gl/package.go
@@ -19427,7 +19427,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20073,9 +20073,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20261,7 +20261,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20737,9 +20737,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22165,7 +22165,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22668,9 +22668,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22947,7 +22947,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -28026,7 +28026,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v4.1-core/gl/package.go
+++ b/v4.1-core/gl/package.go
@@ -5460,7 +5460,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5631,9 +5631,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5736,7 +5736,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5941,9 +5941,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6450,7 +6450,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6760,7 +6760,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8162,7 +8162,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v4.2-compatibility/gl/package.go
+++ b/v4.2-compatibility/gl/package.go
@@ -19431,7 +19431,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20077,9 +20077,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20265,7 +20265,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20741,9 +20741,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22169,7 +22169,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22672,9 +22672,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22951,7 +22951,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -28030,7 +28030,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v4.2-core/gl/package.go
+++ b/v4.2-core/gl/package.go
@@ -5464,7 +5464,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5635,9 +5635,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5740,7 +5740,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5945,9 +5945,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6454,7 +6454,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6764,7 +6764,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8166,7 +8166,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v4.3-compatibility/gl/package.go
+++ b/v4.3-compatibility/gl/package.go
@@ -19434,7 +19434,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20080,9 +20080,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20268,7 +20268,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20744,9 +20744,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22172,7 +22172,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22675,9 +22675,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22954,7 +22954,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -28033,7 +28033,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v4.3-core/gl/package.go
+++ b/v4.3-core/gl/package.go
@@ -5467,7 +5467,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5638,9 +5638,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5743,7 +5743,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5948,9 +5948,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6457,7 +6457,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6767,7 +6767,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8169,7 +8169,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v4.4-compatibility/gl/package.go
+++ b/v4.4-compatibility/gl/package.go
@@ -19437,7 +19437,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20083,9 +20083,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20271,7 +20271,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20747,9 +20747,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22175,7 +22175,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22678,9 +22678,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -22957,7 +22957,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -28036,7 +28036,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v4.4-core/gl/package.go
+++ b/v4.4-core/gl/package.go
@@ -5470,7 +5470,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5641,9 +5641,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5746,7 +5746,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5951,9 +5951,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6460,7 +6460,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6770,7 +6770,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8172,7 +8172,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 

--- a/v4.5-compatibility/gl/package.go
+++ b/v4.5-compatibility/gl/package.go
@@ -19513,7 +19513,7 @@ func ClientAttribDefaultEXT(mask uint32) {
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -20159,9 +20159,9 @@ func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -20347,7 +20347,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -20823,9 +20823,9 @@ func FeedbackBufferxOES(n int32, xtype uint32, buffer *int32) {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func FinalCombinerInputNV(variable uint32, input uint32, mapping uint32, componentUsage uint32) {
 	C.glowFinalCombinerInputNV(gpFinalCombinerInputNV, (C.GLenum)(variable), (C.GLenum)(input), (C.GLenum)(mapping), (C.GLenum)(componentUsage))
@@ -22251,7 +22251,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 func GetTexBumpParameterfvATI(pname uint32, param *float32) {
@@ -22803,9 +22803,9 @@ func ImageTransformParameteriHP(target uint32, pname uint32, param int32) {
 func ImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowImageTransformParameterivHP(gpImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) unsafe.Pointer {
+func ImportSyncEXT(external_sync_type uint32, external_sync int, flags uint32) uintptr {
 	ret := C.glowImportSyncEXT(gpImportSyncEXT, (C.GLenum)(external_sync_type), (C.GLintptr)(external_sync), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 func IndexFormatNV(xtype uint32, stride int32) {
 	C.glowIndexFormatNV(gpIndexFormatNV, (C.GLenum)(xtype), (C.GLsizei)(stride))
@@ -23082,7 +23082,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -28161,7 +28161,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 func WeightPathsNV(resultPath uint32, numPaths int32, paths *uint32, weights *float32) {

--- a/v4.5-core/gl/package.go
+++ b/v4.5-core/gl/package.go
@@ -5486,7 +5486,7 @@ func ClearTexSubImage(texture uint32, level int32, xoffset int32, yoffset int32,
 }
 
 // block and wait for a sync object to become signaled
-func ClientWaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) uint32 {
+func ClientWaitSync(sync uintptr, flags uint32, timeout uint64) uint32 {
 	ret := C.glowClientWaitSync(gpClientWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 	return (uint32)(ret)
 }
@@ -5657,9 +5657,9 @@ func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) unsafe.Pointer {
+func CreateSyncFromCLeventARB(context *C.struct__cl_context, event *C.struct__cl_event, flags uint32) uintptr {
 	ret := C.glowCreateSyncFromCLeventARB(gpCreateSyncFromCLeventARB, (*C.struct__cl_context)(unsafe.Pointer(context)), (*C.struct__cl_event)(unsafe.Pointer(event)), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // create texture objects
@@ -5762,7 +5762,7 @@ func DeleteShader(shader uint32) {
 }
 
 // delete a sync object
-func DeleteSync(sync unsafe.Pointer) {
+func DeleteSync(sync uintptr) {
 	C.glowDeleteSync(gpDeleteSync, (C.GLsync)(sync))
 }
 
@@ -5967,9 +5967,9 @@ func EndTransformFeedback() {
 }
 
 // create a new sync object and insert it into the GL command stream
-func FenceSync(condition uint32, flags uint32) unsafe.Pointer {
+func FenceSync(condition uint32, flags uint32) uintptr {
 	ret := C.glowFenceSync(gpFenceSync, (C.GLenum)(condition), (C.GLbitfield)(flags))
-	return (unsafe.Pointer)(ret)
+	return (uintptr)(ret)
 }
 
 // block until all GL execution is complete
@@ -6476,7 +6476,7 @@ func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8
 }
 
 // query the properties of a sync object
-func GetSynciv(sync unsafe.Pointer, pname uint32, bufSize int32, length *int32, values *int32) {
+func GetSynciv(sync uintptr, pname uint32, bufSize int32, length *int32, values *int32) {
 	C.glowGetSynciv(gpGetSynciv, (C.GLsync)(sync), (C.GLenum)(pname), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(values)))
 }
 
@@ -6799,7 +6799,7 @@ func IsShader(shader uint32) bool {
 }
 
 // determine if a name corresponds to a sync object
-func IsSync(sync unsafe.Pointer) bool {
+func IsSync(sync uintptr) bool {
 	ret := C.glowIsSync(gpIsSync, (C.GLsync)(sync))
 	return ret == TRUE
 }
@@ -8201,7 +8201,7 @@ func ViewportIndexedfv(index uint32, v *float32) {
 }
 
 // instruct the GL server to block until the specified sync object becomes signaled
-func WaitSync(sync unsafe.Pointer, flags uint32, timeout uint64) {
+func WaitSync(sync uintptr, flags uint32, timeout uint64) {
 	C.glowWaitSync(gpWaitSync, (C.GLsync)(sync), (C.GLbitfield)(flags), (C.GLuint64)(timeout))
 }
 


### PR DESCRIPTION
Regenerate all bindings after generator change in go-gl/glow#79.

Done with latest version of glow:

	go generate -tags=gen github.com/go-gl/gl

Resolves #71.

/cc @errcw @dominikh