### PR TITLE
Travis: Update Go versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
     - libgles2-mesa-dev
 language: go
 go:
+  - 1.4.x
   - 1.5.x
   - 1.6.x
   - 1.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ addons:
     - libgles2-mesa-dev
 language: go
 go:
-  - 1.4.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
   - 1.8.x
+  - 1.4.x
   - master
 matrix:
   allow_failures:
@@ -17,7 +14,6 @@ matrix:
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-  - free -m
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - # vet is reporting "possible misuse of unsafe.Pointer", need to fix that.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
+  - free -h
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - # vet is reporting "possible misuse of unsafe.Pointer", need to fix that.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-  - free -h
+  - free -m
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
   - # vet is reporting "possible misuse of unsafe.Pointer", need to fix that.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ addons:
     - libgles2-mesa-dev
 language: go
 go:
-  - 1.5.2
-  - tip
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - master
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).


### PR DESCRIPTION
Travis now refers to "tip" as "master".

Reference: https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use.