### PR TITLE
README: Update reference to renamed example repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A note about threading and goroutines. The bindings do not expose a mechanism to
 Examples
 --------
 
-Examples illustrating how to use the bindings are available in the [examples](https://github.com/go-gl/examples) repo. There are examples for [OpenGL 4.1 core](https://github.com/go-gl/example/tree/master/gl41core-cube) and [OpenGL 2.1](https://github.com/go-gl/example/tree/master/gl21-cube).
+Examples illustrating how to use the bindings are available in the [example](https://github.com/go-gl/example) repo. There are examples for [OpenGL 4.1 core](https://github.com/go-gl/example/tree/master/gl41core-cube) and [OpenGL 2.1](https://github.com/go-gl/example/tree/master/gl21-cube).
 
 Function Loading
 ----------------


### PR DESCRIPTION
The old link still worked thanks to the GitHub redirect, but it's better to point to the new repo directly.

Updates go-gl/example#58.
Follows #78.

@errcw, when merging this PR, let's use squash or rebase strategy so this creates a single commit, rather than merge strategy that creates 2 commits (actual change commit + a merge commit).