### PR TITLE
Regenerate bindings for #85

### DIFF
--- a/all-core/gl/procaddr.go
+++ b/all-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcoreall(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcoreall(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcoreall(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcoreall(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcoreall(cname)
 }

--- a/v2.1/gl/procaddr.go
+++ b/v2.1/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gl21(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gl21(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gl21(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gl21(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_gl21(cname)
 }

--- a/v3.1/gles2/procaddr.go
+++ b/v3.1/gles2/procaddr.go
@@ -23,7 +23,7 @@ package gles2
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gles231(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gles2
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gles231(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gles2
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gles231(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_gles231(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_gles231(cname)
 }

--- a/v3.2-compatibility/gl/procaddr.go
+++ b/v3.2-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility32(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility32(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility32(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility32(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility32(cname)
 }

--- a/v3.2-core/gl/procaddr.go
+++ b/v3.2-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore32(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore32(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore32(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore32(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore32(cname)
 }

--- a/v3.3-compatibility/gl/procaddr.go
+++ b/v3.3-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility33(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility33(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility33(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility33(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility33(cname)
 }

--- a/v3.3-core/gl/procaddr.go
+++ b/v3.3-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore33(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore33(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore33(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore33(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore33(cname)
 }

--- a/v4.1-compatibility/gl/procaddr.go
+++ b/v4.1-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility41(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility41(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility41(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility41(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility41(cname)
 }

--- a/v4.1-core/gl/procaddr.go
+++ b/v4.1-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore41(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore41(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore41(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore41(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore41(cname)
 }

--- a/v4.2-compatibility/gl/procaddr.go
+++ b/v4.2-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility42(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility42(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility42(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility42(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility42(cname)
 }

--- a/v4.2-core/gl/procaddr.go
+++ b/v4.2-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore42(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore42(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore42(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore42(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore42(cname)
 }

--- a/v4.3-compatibility/gl/procaddr.go
+++ b/v4.3-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility43(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility43(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility43(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility43(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility43(cname)
 }

--- a/v4.3-core/gl/procaddr.go
+++ b/v4.3-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore43(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore43(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore43(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore43(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore43(cname)
 }

--- a/v4.4-compatibility/gl/procaddr.go
+++ b/v4.4-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility44(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility44(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility44(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility44(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility44(cname)
 }

--- a/v4.4-core/gl/procaddr.go
+++ b/v4.4-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore44(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore44(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore44(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore44(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore44(cname)
 }

--- a/v4.5-compatibility/gl/procaddr.go
+++ b/v4.5-compatibility/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility45(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility45(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility45(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcompatibility45(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcompatibility45(cname)
 }

--- a/v4.5-core/gl/procaddr.go
+++ b/v4.5-core/gl/procaddr.go
@@ -23,7 +23,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore45(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -31,7 +31,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore45(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -44,13 +44,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore45(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress(const char* name) {
+	void* GlowGetProcAddress_glcore45(const char* name) {
 		return glXGetProcAddress(name);
 	}
 #endif
@@ -61,5 +61,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress(cname)
+	return C.GlowGetProcAddress_glcore45(cname)
 }


### PR DESCRIPTION
Regenerates bindings after making GlowGetProcAddress unique in C code via 02530883bc2794702b56c9c83c6838b554cf5688 in glow.

Fixes #85, based on https://github.com/go-gl/glow/pull/87