### PR TITLE
Re issue #97 - go fails to build on FreeBSD

### DIFF
--- a/v3.2-core/gl/procaddr.go
+++ b/v3.2-core/gl/procaddr.go
@@ -14,8 +14,9 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
+#cgo linux freebsd CFLAGS: -DTAG_POSIX -I/usr/local/include
 #cgo linux freebsd LDFLAGS: -lGL
+#cgo linux freebsd pkg-config: gl
 #cgo egl CFLAGS: -DTAG_EGL
 #cgo egl LDFLAGS: -lEGL
 // Check the EGL tag first as it takes priority over the platform's default


### PR DESCRIPTION
Changes necessary to get go-gl to compile on FreeBSD, re issue #97