### PR TITLE
all: Use pkg-config

### DIFF
--- a/all-core/gl/package.go
+++ b/all-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/all-core/gl/procaddr.go
+++ b/all-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v2.1/gl/package.go
+++ b/v2.1/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v2.1/gl/procaddr.go
+++ b/v2.1/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v3.1/gles2/package.go
+++ b/v3.1/gles2/package.go
@@ -17,8 +17,9 @@
 package gles2
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v3.1/gles2/procaddr.go
+++ b/v3.1/gles2/procaddr.go
@@ -20,10 +20,10 @@ package gles2
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v3.2-compatibility/gl/package.go
+++ b/v3.2-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v3.2-compatibility/gl/procaddr.go
+++ b/v3.2-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v3.2-core/gl/package.go
+++ b/v3.2-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v3.2-core/gl/procaddr.go
+++ b/v3.2-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v3.3-compatibility/gl/package.go
+++ b/v3.3-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v3.3-compatibility/gl/procaddr.go
+++ b/v3.3-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v3.3-core/gl/package.go
+++ b/v3.3-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v3.3-core/gl/procaddr.go
+++ b/v3.3-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.1-compatibility/gl/package.go
+++ b/v4.1-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.1-compatibility/gl/procaddr.go
+++ b/v4.1-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.1-core/gl/package.go
+++ b/v4.1-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.1-core/gl/procaddr.go
+++ b/v4.1-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.2-compatibility/gl/package.go
+++ b/v4.2-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.2-compatibility/gl/procaddr.go
+++ b/v4.2-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.2-core/gl/package.go
+++ b/v4.2-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.2-core/gl/procaddr.go
+++ b/v4.2-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.3-compatibility/gl/package.go
+++ b/v4.3-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.3-compatibility/gl/procaddr.go
+++ b/v4.3-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.3-core/gl/package.go
+++ b/v4.3-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.3-core/gl/procaddr.go
+++ b/v4.3-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.4-compatibility/gl/package.go
+++ b/v4.4-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.4-compatibility/gl/procaddr.go
+++ b/v4.4-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.4-core/gl/package.go
+++ b/v4.4-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.4-core/gl/procaddr.go
+++ b/v4.4-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.5-compatibility/gl/package.go
+++ b/v4.5-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.5-compatibility/gl/procaddr.go
+++ b/v4.5-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.5-core/gl/package.go
+++ b/v4.5-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.5-core/gl/procaddr.go
+++ b/v4.5-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.6-compatibility/gl/package.go
+++ b/v4.6-compatibility/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.6-compatibility/gl/procaddr.go
+++ b/v4.6-compatibility/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)

--- a/v4.6-core/gl/package.go
+++ b/v4.6-core/gl/package.go
@@ -17,8 +17,9 @@
 package gl
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN
 // #define WIN32_LEAN_AND_MEAN 1

--- a/v4.6-core/gl/procaddr.go
+++ b/v4.6-core/gl/procaddr.go
@@ -20,10 +20,10 @@ package gl
 #cgo windows LDFLAGS: -lopengl32
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)


### PR DESCRIPTION
This applies the glow change go-gl/glow#103 to use pkg-config for both Linux and FreeBSD which fixes building on the latter.