### PR TITLE
Support EGL+OpenGLES2 (with ANGLE) on macOS

### DIFF
--- a/v3.1/gles2/package.go
+++ b/v3.1/gles2/package.go
@@ -16,7 +16,8 @@
 //
 package gles2
 
-// #cgo darwin        LDFLAGS: -framework OpenGL
+// #cgo !gles2,darwin        LDFLAGS: -framework OpenGL
+// #cgo gles2,darwin         LDFLAGS: -lGLESv2
 // #cgo !gles2,windows       LDFLAGS: -lopengl32
 // #cgo gles2,windows        LDFLAGS: -lGLESv2
 // #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl

--- a/v3.1/gles2/procaddr.go
+++ b/v3.1/gles2/procaddr.go
@@ -20,12 +20,14 @@ package gles2
 #cgo !gles2,windows       LDFLAGS: -lopengl32
 #cgo gles2,windows        LDFLAGS: -lGLESv2
 #cgo darwin CFLAGS: -DTAG_DARWIN
-#cgo darwin LDFLAGS: -framework OpenGL
+#cgo !gles2,darwin LDFLAGS: -framework OpenGL
+#cgo gles2,darwin  LDFLAGS: -lGLESv2
 #cgo linux freebsd openbsd CFLAGS: -DTAG_POSIX
 #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl
 #cgo egl,linux egl,freebsd egl,openbsd egl,windows CFLAGS: -DTAG_EGL
 #cgo egl,linux egl,freebsd egl,openbsd pkg-config: egl
 #cgo egl,windows LDFLAGS: -lEGL
+#cgo egl,darwin  LDFLAGS: -lEGL
 // Check the EGL tag first as it takes priority over the platform's default
 // configuration of WGL/GLX/CGL.
 #if defined(TAG_EGL)


### PR DESCRIPTION
Default still using Desktop OpenGL

This includes the go-gl/Glow change here: https://github.com/go-gl/glow/pull/114