### PR TITLE
Make the workflow a bit more reliable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+
 name: Main
 on: [push, pull_request]
 jobs:
@@ -7,21 +8,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.17, 1.16, 1.15, 1.14, 1.13, 1.12]
+        go-version: [1.17, 1.12]
         os: [macos-latest, windows-latest, ubuntu-latest]
+
     steps:
     - name: Install dependencies (linux)
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: sudo apt-get install libgl1-mesa-dev
+      run: sudo apt-get update && sudo apt-get install libgl1-mesa-dev
+
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{matrix.go-version}}
-    - name: Print go version
-      run: go version
+
     - name: Check out module
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         fetch-depth: 1
+
     - name: Run tests
       run: go test -v -race ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-
 name: Main
 on: [push, pull_request]
 jobs:


### PR DESCRIPTION
This makes a few changes. Most importantly, it fixes the installation of deps. This was due to the repo list not being updated and partly because apt-get is a terrible package manager (in my opinion) and thus doesn't do it automatically.

The tests now only run for the oldest and newest Go versions only as if it works on both of those, we can literally say that anything between is a bug in Go and not here. Apart from that, it is mostly some clean-ups and updates to the used actions.

However, I saw that there is a no test files here, so the tests actually passing does not give us much reassurance.