### PR TITLE
Remove `$PATH/glow` requirement for running `go generate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ It is required to have `glow` source in a sibling directory to `go-gl/gl` since 
 For non-module-aware cases, this means `glow` needs to be in the same Go workspace as `go-gl/gl`.
 For module-aware cases, `go-gl/glow` needs to be checked out parallel to `go-gl/gl`. 
 
-In either case, the `glow` binary must be in your `$PATH`. Doable with `go get -u github.com/go-gl/glow` if your `$GOPATH/bin` is in your `$PATH`.
-
 Perform generation with the following:
 
 ```bash

--- a/all-core/gl/KHR/dummy.go
+++ b/all-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/all-core/gl/build_cgo_hack.go
+++ b/all-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/all-core/gl/conversions.go
+++ b/all-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/all-core/gl/package.go
+++ b/all-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/all-core/gl/procaddr.go
+++ b/all-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcoreall(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcoreall(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcoreall(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcoreall(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcoreall(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/generate.go
+++ b/generate.go
@@ -1,5 +1,6 @@
 // +build gen
 
+//go:generate -command glow go run ../glow/
 //go:generate glow generate -out=./v2.1/gl/ -api=gl -version=2.1 -xml=../glow/xml/ -tmpl=../glow/tmpl/
 //go:generate glow generate -out=./all-core/gl/ -api=gl -version=all -profile=core -lenientInit -xml=../glow/xml/ -tmpl=../glow/tmpl/
 //go:generate glow generate -out=./v3.2-core/gl/ -api=gl -version=3.2 -profile=core -xml=../glow/xml/ -tmpl=../glow/tmpl/

--- a/v2.1/gl/KHR/dummy.go
+++ b/v2.1/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v2.1/gl/build_cgo_hack.go
+++ b/v2.1/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v2.1/gl/conversions.go
+++ b/v2.1/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v2.1/gl/package.go
+++ b/v2.1/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v2.1/gl/procaddr.go
+++ b/v2.1/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_gl21(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_gl21(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_gl21(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_gl21(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_gl21(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.0/gles2/conversions.go
+++ b/v3.0/gles2/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.0/gles2/package.go
+++ b/v3.0/gles2/package.go
@@ -12,8 +12,8 @@
 // Package gles2 implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gles2
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.0/gles2/procaddr.go
+++ b/v3.0/gles2/procaddr.go
@@ -33,7 +33,7 @@ package gles2
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_gles230(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gles2
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_gles230(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gles2
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_gles230(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_gles230(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_gles230(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.1/gles2/KHR/dummy.go
+++ b/v3.1/gles2/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v3.1/gles2/build_cgo_hack.go
+++ b/v3.1/gles2/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gles2

--- a/v3.1/gles2/conversions.go
+++ b/v3.1/gles2/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.1/gles2/package.go
+++ b/v3.1/gles2/package.go
@@ -12,8 +12,8 @@
 // Package gles2 implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gles2
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.1/gles2/procaddr.go
+++ b/v3.1/gles2/procaddr.go
@@ -33,7 +33,7 @@ package gles2
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_gles231(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gles2
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_gles231(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gles2
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_gles231(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_gles231(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_gles231(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.2-compatibility/gl/KHR/dummy.go
+++ b/v3.2-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v3.2-compatibility/gl/build_cgo_hack.go
+++ b/v3.2-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v3.2-compatibility/gl/conversions.go
+++ b/v3.2-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.2-compatibility/gl/package.go
+++ b/v3.2-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.2-compatibility/gl/procaddr.go
+++ b/v3.2-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility32(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.2-core/gl/KHR/dummy.go
+++ b/v3.2-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v3.2-core/gl/build_cgo_hack.go
+++ b/v3.2-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v3.2-core/gl/conversions.go
+++ b/v3.2-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.2-core/gl/package.go
+++ b/v3.2-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.2-core/gl/procaddr.go
+++ b/v3.2-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore32(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore32(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.3-compatibility/gl/KHR/dummy.go
+++ b/v3.3-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v3.3-compatibility/gl/build_cgo_hack.go
+++ b/v3.3-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v3.3-compatibility/gl/conversions.go
+++ b/v3.3-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.3-compatibility/gl/package.go
+++ b/v3.3-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.3-compatibility/gl/procaddr.go
+++ b/v3.3-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility33(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v3.3-core/gl/KHR/dummy.go
+++ b/v3.3-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v3.3-core/gl/build_cgo_hack.go
+++ b/v3.3-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v3.3-core/gl/conversions.go
+++ b/v3.3-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v3.3-core/gl/package.go
+++ b/v3.3-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v3.3-core/gl/procaddr.go
+++ b/v3.3-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore33(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore33(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.1-compatibility/gl/KHR/dummy.go
+++ b/v4.1-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.1-compatibility/gl/build_cgo_hack.go
+++ b/v4.1-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.1-compatibility/gl/conversions.go
+++ b/v4.1-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.1-compatibility/gl/package.go
+++ b/v4.1-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.1-compatibility/gl/procaddr.go
+++ b/v4.1-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility41(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.1-core/gl/KHR/dummy.go
+++ b/v4.1-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.1-core/gl/build_cgo_hack.go
+++ b/v4.1-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.1-core/gl/conversions.go
+++ b/v4.1-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.1-core/gl/package.go
+++ b/v4.1-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.1-core/gl/procaddr.go
+++ b/v4.1-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore41(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore41(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.2-compatibility/gl/KHR/dummy.go
+++ b/v4.2-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.2-compatibility/gl/build_cgo_hack.go
+++ b/v4.2-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.2-compatibility/gl/conversions.go
+++ b/v4.2-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.2-compatibility/gl/package.go
+++ b/v4.2-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.2-compatibility/gl/procaddr.go
+++ b/v4.2-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility42(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.2-core/gl/KHR/dummy.go
+++ b/v4.2-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.2-core/gl/build_cgo_hack.go
+++ b/v4.2-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.2-core/gl/conversions.go
+++ b/v4.2-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.2-core/gl/package.go
+++ b/v4.2-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.2-core/gl/procaddr.go
+++ b/v4.2-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore42(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore42(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.3-compatibility/gl/KHR/dummy.go
+++ b/v4.3-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.3-compatibility/gl/build_cgo_hack.go
+++ b/v4.3-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.3-compatibility/gl/conversions.go
+++ b/v4.3-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.3-compatibility/gl/package.go
+++ b/v4.3-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.3-compatibility/gl/procaddr.go
+++ b/v4.3-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility43(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.3-core/gl/KHR/dummy.go
+++ b/v4.3-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.3-core/gl/build_cgo_hack.go
+++ b/v4.3-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.3-core/gl/conversions.go
+++ b/v4.3-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.3-core/gl/package.go
+++ b/v4.3-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.3-core/gl/procaddr.go
+++ b/v4.3-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore43(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore43(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.4-compatibility/gl/KHR/dummy.go
+++ b/v4.4-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.4-compatibility/gl/build_cgo_hack.go
+++ b/v4.4-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.4-compatibility/gl/conversions.go
+++ b/v4.4-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.4-compatibility/gl/package.go
+++ b/v4.4-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.4-compatibility/gl/procaddr.go
+++ b/v4.4-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility44(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.4-core/gl/KHR/dummy.go
+++ b/v4.4-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.4-core/gl/build_cgo_hack.go
+++ b/v4.4-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.4-core/gl/conversions.go
+++ b/v4.4-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.4-core/gl/package.go
+++ b/v4.4-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.4-core/gl/procaddr.go
+++ b/v4.4-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore44(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore44(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.5-compatibility/gl/KHR/dummy.go
+++ b/v4.5-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.5-compatibility/gl/build_cgo_hack.go
+++ b/v4.5-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.5-compatibility/gl/conversions.go
+++ b/v4.5-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.5-compatibility/gl/package.go
+++ b/v4.5-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.5-compatibility/gl/procaddr.go
+++ b/v4.5-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility45(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.5-core/gl/KHR/dummy.go
+++ b/v4.5-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.5-core/gl/build_cgo_hack.go
+++ b/v4.5-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.5-core/gl/conversions.go
+++ b/v4.5-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.5-core/gl/package.go
+++ b/v4.5-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.5-core/gl/procaddr.go
+++ b/v4.5-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore45(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore45(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.6-compatibility/gl/KHR/dummy.go
+++ b/v4.6-compatibility/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.6-compatibility/gl/build_cgo_hack.go
+++ b/v4.6-compatibility/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.6-compatibility/gl/conversions.go
+++ b/v4.6-compatibility/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.6-compatibility/gl/package.go
+++ b/v4.6-compatibility/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.6-compatibility/gl/procaddr.go
+++ b/v4.6-compatibility/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcompatibility46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcompatibility46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcompatibility46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcompatibility46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcompatibility46(cname)
+	return C.GlowGetProcAddress(cname)
 }

--- a/v4.6-core/gl/KHR/dummy.go
+++ b/v4.6-core/gl/KHR/dummy.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 // Package dummy prevents go tooling from stripping the c dependencies.

--- a/v4.6-core/gl/build_cgo_hack.go
+++ b/v4.6-core/gl/build_cgo_hack.go
@@ -1,3 +1,4 @@
+//go:build required
 // +build required
 
 package gl

--- a/v4.6-core/gl/conversions.go
+++ b/v4.6-core/gl/conversions.go
@@ -17,9 +17,9 @@ import "C"
 //
 // For example:
 //
-// 	var data []uint8
-// 	...
-// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
+//	var data []uint8
+//	...
+//	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/v4.6-core/gl/package.go
+++ b/v4.6-core/gl/package.go
@@ -12,8 +12,8 @@
 // Package gl implements Go bindings to OpenGL.
 //
 // This package was automatically generated using Glow:
-//  https://github.com/go-gl/glow
 //
+//	https://github.com/go-gl/glow
 package gl
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL

--- a/v4.6-core/gl/procaddr.go
+++ b/v4.6-core/gl/procaddr.go
@@ -33,7 +33,7 @@ package gl
 #if defined(TAG_EGL)
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_glcore46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 #elif defined(TAG_WINDOWS)
@@ -41,7 +41,7 @@ package gl
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_glcore46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -54,13 +54,13 @@ package gl
 #elif defined(TAG_DARWIN)
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_glcore46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 #elif defined(TAG_POSIX)
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_glcore46(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 #endif
@@ -71,5 +71,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_glcore46(cname)
+	return C.GlowGetProcAddress(cname)
 }


### PR DESCRIPTION
Switches to running `glow` via `go run ../glow/`, which makes it easier to sync changes between the two repositories.