### PR TITLE
Fix broken workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,23 +7,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.17, 1.12]
+        go-version: ['stable']
         os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            go-version: ''
 
     steps:
     - name: Install dependencies (linux)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get update && sudo apt-get install libgl1-mesa-dev
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{matrix.go-version}}
-
     - name: Check out module
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{matrix.go-version}}
+        go-version-file: go.mod
 
     - name: Run tests
       run: go test -v -race ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libgl1-mesa-dev
 
     - name: Check out module
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
The `go 1.12` test is currently failing for `macos-latest` because it's now on `arm64`, which only goes back to `go 1.19`. See https://github.com/go-gl/gl/actions/runs/9686520667/job/26729113129 

This PR resolves this by removing the `go 1.12`+`macos-latest` and `go 1.12`+`windows-latest` tests, leaving only `ubuntu-latest` since it's the most stable OS for old Go versions. Note that `go 1.17` is still being tested with all three OS's.

I also took the opportunity to change `go-versions` from `go 1.12`+`go 1.17` to `go.mod`+`stable` to future-proof the workflow a little bit better.

